### PR TITLE
Fix crash in electron app when loading model

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You can get a list of supported devices with:
 
 ### Options
 
+* `asar`: For electron applications, whether asar archiving is enabled or not. Default `false`.
 * `consecutiveFramesForSilence`: How many frames of audio must be silent before `onChunkEnd` is fired. Default `10`.
 * `consecutiveFramesForSpeaking`: How many frames of audio must be speech before `onChunkStart` is fired. Default `1`.
 * `leadingBufferFrames`: How many frames of audio to keep in a buffer that's included in `onChunkStart`. Default `10`.

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ class Wrapper {
       options.webrtcVadResultsSize !== undefined ? options.webrtcVadResultsSize : 10;
 
     this.inner = new SpeechRecorder(
-      model !== undefined ? model : path.join(__dirname, "..", "lib", "resources", "vad.onnx"),
+      model !== undefined ? model : path.join(__dirname, "..", "lib", "resources", "vad.onnx").replace('app.asar', 'app.asar.unpacked'),
       (event, data) => {
         if (event == "chunkStart") {
           options.onChunkStart({ audio: data.audio });

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const { SpeechRecorder, devices } = require("bindings")("speechrecorder.node");
 class Wrapper {
   constructor(options, model) {
     options = options ? options : {};
+    options.asar = options.asar !== undefined ? options.asar : false;
     options.consecutiveFramesForSilence =
       options.consecutiveFramesForSilence !== undefined ? options.consecutiveFramesForSilence : 10;
     options.consecutiveFramesForSpeaking =
@@ -33,8 +34,11 @@ class Wrapper {
     options.webrtcVadResultsSize =
       options.webrtcVadResultsSize !== undefined ? options.webrtcVadResultsSize : 10;
 
+    let defaultModelPath = path.join(__dirname, "..", "lib", "resources", "vad.onnx");
+    if (options.asar) defaultModelPath = defaultModelPath.replace('app.asar', 'app.asar.unpacked');
+
     this.inner = new SpeechRecorder(
-      model !== undefined ? model : path.join(__dirname, "..", "lib", "resources", "vad.onnx").replace('app.asar', 'app.asar.unpacked'),
+      model !== undefined ? model : defaultModelPath,
       (event, data) => {
         if (event == "chunkStart") {
           options.onChunkStart({ audio: data.audio });


### PR DESCRIPTION
This PR fixes crashes in electron applications that use asar archiving (as seen in https://github.com/serenadeai/speech-recorder/issues/30), which is enabled by default in electron.
When using asar archiving, native dependencies such as speech-recorder are not bundled in the asar file, remaining in the separate path app.asar.unpacked.

As seen in https://github.com/electron/electron/issues/6262, Electron has trouble using __dirname, as the asar bundling messes with the paths for dependencies: __dirname will resolve to a path with app.asar in it, while it should actually have app.asar.unpacked. For now, there is no fix or API for handling this on electron, so this simple replace should address the problem (which is the approach taken in the issue above).